### PR TITLE
fixed warning caused by django 1.5 update

### DIFF
--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls.static import static
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.conf import settings
 
 from django.contrib import admin


### PR DESCRIPTION
I just changed the urls.py file to replace the deprecated

```
django.conf.urls.defaults 
```

with 

```
django.conf.urls 
```

as found in the warning message.  Here's the relevant code from ..defaults.py:

```
import warnings
warnings.warn("django.conf.urls.defaults is deprecated; use django.conf.urls instead",
          DeprecationWarning)

from django.conf.urls import (handler403, handler404, handler500,
    include, patterns, url)
```

Hopefully this isn't considered too trivial, it's my first pull request, be gentle.
