### PR TITLE
More flexible pip requirements.txt layout

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,8 +1,0 @@
-# This file collects all required third-party applications that are needed
-# to run this project. Later you can install all these apps in a row
-# using pip. Example::
-#
-#     pip install -r requirements.pip
-
-django==1.4.1
-#south==0.7.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# You can install all these apps in a row using pip. Example::
+# You can install all these apps using pip. Example::
 #
 #     pip install -r requirements.txt
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# You can install all these apps in a row using pip. Example::
+#
+#     pip install -r requirements.txt
+#
+# Or you can install a more specific set of requirements, for example::
+#
+#     pip install -r requirements/dev.txt
+
+-r requirements/prod.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,31 +1,7 @@
 # This pip requirements list includes all the basic project requirements that
 # should be common for any deployed environment.
 #
-# It is ideal to lock every package down to a specific version.
+# It is ideal to pin packages to specific versions.
 
-Django==1.4
-psycopg2==2.4.1
-#uwsgi
-
-django-secure
-#django-bcrypt
-#py-bcrypt
-
-# TastyPie!
-#-e git+https://github.com/toastdriven/django-tastypie.git#egg=django-tastypie
-
-# Sentry
-#django-sentry
-#django-indexer
-#django-paging
-#django-templatetag-sugar
-#raven
-
-# Deployment
-#south
-fabric
-
-# Testing & Documentation
-#django-debug-toolbar
-factory-boy
-pep8
+django==1.4.1
+#south==0.7.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,31 @@
+# This pip requirements list includes all the basic project requirements that
+# should be common for any deployed environment.
+#
+# It is ideal to lock every package down to a specific version.
+
+Django==1.4
+psycopg2==2.4.1
+#uwsgi
+
+django-secure
+#django-bcrypt
+#py-bcrypt
+
+# TastyPie!
+#-e git+https://github.com/toastdriven/django-tastypie.git#egg=django-tastypie
+
+# Sentry
+#django-sentry
+#django-indexer
+#django-paging
+#django-templatetag-sugar
+#raven
+
+# Deployment
+#south
+fabric
+
+# Testing & Documentation
+#django-debug-toolbar
+factory-boy
+pep8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,5 @@
-# This pip requirements list includes all the basic project requirements that
-# should be common for any deployed environment.
-#
-# It is ideal to pin packages to specific versions.
+# These are the base requirements that are common for any of our deployed
+# environments.
 
 django==1.4.1
 #south==0.7.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,13 +1,3 @@
 # Development environment requirements
 
 -r base.txt
-
-requests
-ipdb
-
-# Testing & Documentation
-#django-debug-toolbar
-coverage
-django-coverage
-Sphinx>=1.0
-#sphinxcontrib-seqdiag

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,15 @@
+-r base.txt
+
+requests
+ipdb
+
+# Mutual Mobile lib
+#svn+https://svn.r.mutualmobile.com/svn/MMSERVENG/tags/mm_core-4.1.0
+#svn+https://svn.r.mutualmobile.com/svn/MMSERVENG/tags/mm_django-3.1.2
+
+# Testing & Documentation
+#django-debug-toolbar
+coverage
+django-coverage
+Sphinx>=1.0
+sphinxcontrib-seqdiag

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,15 +1,13 @@
+# Development environment requirements
+
 -r base.txt
 
 requests
 ipdb
-
-# Mutual Mobile lib
-#svn+https://svn.r.mutualmobile.com/svn/MMSERVENG/tags/mm_core-4.1.0
-#svn+https://svn.r.mutualmobile.com/svn/MMSERVENG/tags/mm_django-3.1.2
 
 # Testing & Documentation
 #django-debug-toolbar
 coverage
 django-coverage
 Sphinx>=1.0
-sphinxcontrib-seqdiag
+#sphinxcontrib-seqdiag

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+# Production environment requirements
+
+-r base.txt


### PR DESCRIPTION
I've re-arranged requirements.pip into a directory that contains a base list of packages (requirements/base.txt) which gets inherited by dev.txt and prod.txt.  The purpose is to modularize the set of requirements that are required for different deployment environments (development, staging, ci, qa, testing, production, etc.)  

For example, we do not want to deploy some django and/or python debugging packages to production servers.  For example: django debug toolbar, ipdb, coverage, pep8, cx_oracle, etc.

I replaced the original requirements.pip with a top level requirements.txt that defaults to the production settings.  (It seems that the ".pip" extension is being phased out, in favor of ".txt")