### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ frequently used in Lincoln Loop's projects, like
 
 To use ``django-layout``:
 
-1. follow the steps for Python instalation from the `Pre-Requisites`_ section;
+1. follow the steps for Python installation from the `Pre-Requisites`_ section;
 2. create and activate a virtualenv::
 
     python3.9 -m venv .venv
@@ -109,7 +109,7 @@ First, create a clean base environment using virtualenv::
 Installing the Project
 ----------------------
 
-Compile requirements to make sure you have all the latests dependencies::
+Compile requirements to make sure you have all the latest dependencies::
 
     make upgrade-pip
     make requirements.txt


### PR DESCRIPTION
There are small typos in:
- README.rst

Fixes:
- Should read `latest` rather than `latests`.
- Should read `installation` rather than `instalation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md