### PR TITLE
Harden Renovate config

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -10,6 +10,11 @@ name: Renovate (Lock File Maintenance)
     - cron: "0 6 * * 4" # 6am UTC on Thursday
   workflow_dispatch:
 
+# Least-privilege workflow token. All gh CLI operations use the App token
+# (GH_TOKEN), not the workflow's GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   approve-lockfile-maintenance:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,13 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+# Least-privilege workflow token. Renovate authenticates via the GitHub App
+# (RENOVATE_TOKEN), so the workflow's GITHUB_TOKEN only needs read access for
+# actions/checkout. Write operations (PRs, branches, comments) go through the
+# App's own permissions, configured at install time.
+permissions:
+  contents: read
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+ignore-scripts=true
 min-release-age=7
 save-exact=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["helpers:pinGitHubActionDigests", ":configMigration", "group:monorepos"],
+  "extends": [
+    ":configMigration",
+    "docker:pinDigests",
+    "group:monorepos",
+    "helpers:pinGitHubActionDigests"
+  ],
   "automerge": true,
   "automergeType": "pr",
   "dependencyDashboard": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
   "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,
   "poetry": {
     "enabled": false


### PR DESCRIPTION
## Summary
- Enable OSV vulnerability alerts and dashboard summary in `renovate.json`
- Add `docker:pinDigests` to `extends` so Docker image references get pinned
- Add `permissions: contents: read` (least-privilege workflow token) to both Renovate workflows
- Add `ignore-scripts=true` to `.npmrc` to block npm lifecycle scripts (supply-chain hardening)

## Test plan
- [x] `pre-commit run renovate-config-validator --all-files` passes
- [ ] CI green
- [ ] Verify next Renovate run picks up the new OSV summary on the dependency dashboard