### PR TITLE
Fix pgdata volume mount for postgres 18

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     volumes:
-      - pgdata:/var/lib/postgresql/data/
+      - pgdata:/var/lib/postgresql
       - .data/db_dumps:/db_dumps
 
   app:


### PR DESCRIPTION
## Summary
Postgres 18 stores data in a major-version subdirectory (`/var/lib/postgresql/18/...`). The volume must mount at `/var/lib/postgresql` (parent) so the subdir layout works. Mounting at `/var/lib/postgresql/data/` causes the container to refuse to start with "in 18+, these Docker images are configured to store database data in a format which is compatible with pg_ctlcluster" — which is why CI has been failing since the pg18 bump.

## Test plan
- [ ] CI green: db container starts, migrations succeed, tests run
- [ ] Local devs need `docker compose down -v` to wipe old `pgdata` volume — old layout is incompatible with pg18 regardless