### PR TITLE
Bypass cooloff for uv, group it with Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,18 @@
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "uv has no release timestamps; skip cooloff.",
+      "matchPackageNames": ["ghcr.io/astral-sh/**"],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": "Bump uv with Python.",
+      "groupName": "python runtime",
+      "matchPackageNames": ["python", "ghcr.io/astral-sh/uv"]
+    }
+  ],
   "platformAutomerge": true,
   "poetry": {
     "enabled": false


### PR DESCRIPTION
uv lives on ghcr.io, which exposes no release timestamps, so `minimumReleaseAge` stalls it indefinitely. Bypass the gate for `ghcr.io/astral-sh/**` and group uv with the Python runtime.