### PR TITLE
Drop redundant tailwindcss dependency from prettier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,6 @@ repos:
           - prettier@3.8.4
           - prettier-plugin-jinja-template@2.2.0
           - prettier-plugin-tailwindcss@0.8.0
-          - tailwindcss@4.3.1
 
   - repo: local
     hooks:


### PR DESCRIPTION
prettier-plugin-tailwindcss bundles its own tailwindcss engine for class sorting (no tailwindcss dependency or peer declared), so installing tailwindcss separately in the hook env is unnecessary. Verified class sorting still works in an isolated env without it.