### PR TITLE
Enforce datetime/typing import conventions via ruff

### DIFF
--- a/project_name/config.py
+++ b/project_name/config.py
@@ -1,7 +1,7 @@
 import base64
 import os
+import typing as t
 from pathlib import Path
-from typing import Literal
 
 from goodconf import Field, GoodConf
 
@@ -22,11 +22,11 @@ class Config(GoodConf):
         description="A string with the database URL as defined in "
         "https://github.com/jazzband/dj-database-url#url-schema",
     )
-    DJANGO_ENV: Literal["development", "dev", "production"] = Field(
+    DJANGO_ENV: t.Literal["development", "dev", "production"] = Field(
         default="production",
         description="Toggle deployment settings for local development or production",
     )
-    LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
+    LOG_LEVEL: t.Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         default="INFO",
         description="Python logging level",
     )

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -12,8 +12,8 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 import contextlib
 import re
+import typing as t
 from pathlib import Path
-from typing import Any
 
 import dj_database_url
 import sentry_sdk
@@ -258,7 +258,7 @@ if config.DJANGO_ENV == "production":
     SECURE_HSTS_PRELOAD = True
 
 
-def _sentry_traces_sampler(ctx: dict[str, Any]) -> float:
+def _sentry_traces_sampler(ctx: dict[str, t.Any]) -> float:
     """Don't capture traces on static files or healthchecks."""
     wsgi_environ = ctx.get("wsgi_environ", {})
     path = wsgi_environ.get("PATH_INFO", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,16 @@ select = ["ALL"]
   "S101",  # Allow use of asserts
 ]
 
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = [
+  "datetime",  # Use `import datetime as dt`, not `from datetime import ...`
+  "typing",  # Use `import typing as t`, not `from typing import ...`
+]
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+datetime = "dt"
+typing = "t"
+
 [tool.uv]
 add-bounds = "exact"
 exclude-newer = "7 days"


### PR DESCRIPTION
Configure ruff `flake8-import-conventions`: require `import datetime as dt` and `import typing as t`, ban `from datetime`/`from typing` imports (`extend-aliases` keeps ruff defaults). Updates `config.py`/`settings.py` to comply.