### PR TITLE
Use exclude_also instead of exclude_lines for coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.egg-info
 *.pyc
+.coverage
+.coverage.*
 .venv
 .vscode
 /.ruff_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,8 @@ requires-python = "==3.14.7"
 version = "4.0"
 
 [tool.coverage.report]
-exclude_lines = [
-  "if TYPE_CHECKING:",
+exclude_also = [
   "if t.TYPE_CHECKING:",
-  "pragma: no cover",
   "raise NotImplementedError",
 ]
 skip_covered = true


### PR DESCRIPTION
`exclude_lines` replaces coverage's built-in defaults; `exclude_also` appends to them. Drops the two entries the defaults already cover (`pragma: no cover`, `if TYPE_CHECKING:`) and restores the `...` stub-body default.

Also gitignores `.coverage` / `.coverage.*` (CI writes `.coverage.$RANDOM`).

Coverage still 100%.